### PR TITLE
fix(slug-paths): prevent path/slug names to have duplicated prefix like `snippets/` or `blog/`

### DIFF
--- a/src/components/cards/blog-card.astro
+++ b/src/components/cards/blog-card.astro
@@ -11,10 +11,12 @@ interface Props {
 
 const { post } = Astro.props
 const category = await getEntry(post.data.category)
+
+const pathname = new URL(post.slug, Astro.site).pathname
 ---
 
 <a
-	href={post.slug}
+	href={pathname}
 	class="group flex h-full flex-col justify-between gap-4 overflow-hidden rounded-md border border-b-4 border-highlight bg-card p-4 pb-2 transition-colors duration-150 ease-in-out hover:border-b-category-highlight hover:bg-card-hover"
 	data-type={category.data.name.toLowerCase()}
 >

--- a/src/components/cards/snippet-card.astro
+++ b/src/components/cards/snippet-card.astro
@@ -11,10 +11,12 @@ interface Props {
 const { snippet, as: Element = 'h4' } = Astro.props
 
 const category = await getEntry(snippet.data.category)
+
+const pathname = new URL(snippet.slug, Astro.site).pathname
 ---
 
 <a
-	href={snippet?.slug}
+	href={pathname}
 	data-type={category?.data.name.toLowerCase()}
 	class="group flex items-center justify-between gap-4 rounded-md border-x border-b-2 border-t border-highlight bg-card p-4 transition-colors duration-150 ease-in-out hover:border-b-category-highlight hover:bg-card-hover"
 	transition:name={snippet.data.title}


### PR DESCRIPTION
## Description

The pathname or slug had prefix added and duplicated on cloudflare pages when user is on the blog or snippets page. This fix uses new URL and Astro.site to merge them. 


## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Tested on wrangler for local development to mimic deployment on CloudFlare pages.

## Screenshots (if applicable)

![Bug on cloudflare pages - duplication](https://github.com/user-attachments/assets/44518864-b91b-40e6-9c54-a900864ada4f)